### PR TITLE
Enhanced numerical stability in information density for Rayleigh Block-fading MIMO no-CSI

### DIFF
--- a/rayleigh-block-fading-no-csi/DT_USTM.m
+++ b/rayleigh-block-fading-no-csi/DT_USTM.m
@@ -61,12 +61,17 @@ for k = 1:K %do K montecarlo runs
                 M = createMalt(Mt,Mr,T,Sigma,lambda2); %create  matrix
                 logdetM=log(det(M))+Sigma(1)*lambda2-(T-Mr)*log(Sigma(1)); 
                 partial_sum=sum(Sigma)-logdetM;
-            else
-                M = createM(Mt,Mr,T,Sigma,lambda2);
-                logdetM=log(det(M)); 
+            elseif Mr >= Mt
+                M = createM_rx_larger(Mt,Mr,T,Sigma,lambda2);
+                logdetM=logdet(M);
                 logdetSigma = (T-Mr)*sum(log(Sigma));% compute logdet(Sigma^(T-M))
                 partial_sum=lambda1*sum(Sigma) - logdetM +logdetSigma;
-            end
+            else
+                logdetM = createM_tx_larger(Mt, Mr, T, Sigma, lambda2); %already in log domain
+                logdetSigma = (T-Mr)*sum(log(Sigma));% compute logdet(Sigma^(T-M))
+                const2 = sum(gammaln(T-((Mt+1):T)+1)) - sum(gammaln(1:(T-Mr)));
+                partial_sum = sum(Sigma) -logdetM + logdetSigma - const2;
+            end            
             
             vanderTerm = det(vander(Sigma)); %get the determinant of the vandermode matrix
             TraceZ=real(trace(Z(:,:,l)'*Z(:,:,l)));
@@ -152,44 +157,117 @@ function val = logComplexGammaRatio(Mt,Mr,T)
     val=val+sum(gammaln(r));
 end
 
+
+
+
 function M = createMalt(Mt,Mr,T,Sigma,lambda)
-    M = nan(Mr,Mr); %(l is the row, k is the column)
-    for l = 1:Mr,
-      for k=1:Mt,      
-        M(l,k)=(Sigma(l)^(Mt-k))*gammainc(lambda*Sigma(l),T+k-Mt-Mr)*exp(lambda*(Sigma(l)-Sigma(1)))*(Sigma(1)/Sigma(l))^(T-Mr);
-      end
-      
-      for k=Mt+1:1:Mr,
-          M(l,k)= Sigma(l)^(Mr-k);
-      end
-        
-    end
-
-                
-end
-
-
-function M = createM(Mt,Mr,T,Sigma,lambda)
-    M = nan(Mr,Mr); %(l is the row, k is the column)
-    P=Mr;
-    
-    for l = 1:Mr,
-        for k=1:Mt,
-                
-            M(l,k)=(Sigma(l)^(Mt-k))*gammainc(lambda*Sigma(l),T+k-Mt-P);
-        end
-        
-        for k=Mt+1:Mr,
-                    
-            M(l,k)=(Sigma(l)^(T-k))*exp(-Sigma(l)*lambda); % case Mt<Mr
-            
-        end
+M = nan(Mr,Mr); %(l is the row, k is the column)
+for l = 1:Mr
+    for k=1:Mt
+        M(l,k)= exp((Mt-k)*log(Sigma(l)) + log(gammainc(lambda*Sigma(l),T+k-Mt-Mr)) + lambda*(Sigma(l)-Sigma(1)) + (T-Mr)*log(Sigma(1)/Sigma(l)));
     end
     
+    for k=Mt+1:1:Mr
+        M(l,k)= Sigma(l)^(Mr-k);
+    end
+end
 end
 
- 
+function M = createM_rx_larger(Mt,Mr,T,Sigma,lambda)
+M = nan(Mr,Mr); %(l is the row, k is the column)
+P=Mr;
 
+for l = 1:Mr
+    for k=1:Mt
+        M(l,k)=(Sigma(l)^(Mt-k))*gammainc(lambda*Sigma(l),T+k-Mt-P);
+    end
+    
+    for k=Mt+1:Mr
+        M(l,k)=exp((T-k)*log(Sigma(l)) -Sigma(l)*lambda); % case Mt<Mr
+    end
+end
+
+end
+
+function C = createM_tx_larger(M,N,T,Sigma,lambda)
+inf_flag = 0;
+A = zeros(max(M,N), max(M,N));
+
+for i = 1:M
+    for j = 1:M
+        if j <= N
+            if Sigma(j) == 0 && M-i == 0
+                A(i,j) = exp(lambda*Sigma(j) + log(gammainc(Sigma(j)*lambda, T-N-M+i-1)));
+            else
+                if (T-N-M+i-1) > 0
+                    A(i,j) = exp((M-i)*log(Sigma(j))  + lambda*Sigma(j) + log(gammainc(Sigma(j)*lambda, T-N-M+i-1)));
+                else
+                    A(i,j) = exp((M-i)*log(Sigma(j))  + lambda*Sigma(j));
+                end
+            end
+            if isinf(A(i,j)) == 1
+                inf_flag = 1;
+                break;
+            end
+            %A(i,j) = exp((M-i)*log(lambda(j))  + gammaln(T-M) +  log(gammainc(lambda(j)*p, T+i-2*M)));
+        else
+            A(i,j) = exp((T-j-(M-i))*log(lambda) + sum(log(T-j-(0:(M-i-1)))));
+            %A(i,j) = exp((T-j-(M-i))*log(p)  + sum(log(T-j-(0:(M-i-1)))));
+        end
+    end
+    if inf_flag == 1
+        break;
+    end
+end
+if inf_flag == 1
+    for i = 1:M
+        for j = 1:M
+            if j <= N
+                if (T-N-M+i-1) > 0
+                    A(i,j) = exp((M-i)*log(Sigma(j))  +  log(gammainc(Sigma(j)*lambda, (T-N-M+i-1))));
+                else
+                    A(i,j) = exp((M-i)*log(Sigma(j)));
+                end
+            else
+                A(i,j) = exp((T-j-(M-i))*log(lambda)  + sum(log(T-j-(0:(M-i-1)))));
+            end
+        end
+    end
+end
+
+if inf_flag == 0
+    C = logdet(A);
+else
+    C = logdet(A) + lambda*sum(Sigma);
+end
+end
+
+function v = logdet(A, op)
+
+assert(isfloat(A) && ndims(A) == 2 && size(A,1) == size(A,2), ...
+    'logdet:invalidarg', ...
+    'A should be a square matrix of double or single class.');
+
+if nargin < 2
+    use_chol = 0;
+else
+    assert(strcmpi(op, 'chol'), ...
+        'logdet:invalidarg', ...
+        'The second argument can only be a string ''chol'' if it is specified.');
+    use_chol = 1;
+end
+
+%% computation
+
+if use_chol
+    v = 2 * sum(log(diag(chol(A))));
+else
+    [L, U, P] = lu(A);
+    du = diag(U);
+    c = det(P) * prod(sign(du));
+    v = log(c) + sum(log(abs(du)));
+end
+end
 
 
 


### PR DESCRIPTION
Updates to improve numerical stability of the information density computation.

- logdet is now computed usign LU factorization
- The M matrix is computed in log domain
- We now separate the case M_t > M_r