### PR TITLE
Fixed refs.bib such that manual.pdf will now compile

### DIFF
--- a/documentation/refs.bib
+++ b/documentation/refs.bib
@@ -53,7 +53,7 @@
 	Author = {Giuseppe Durisi and Tobias Koch and Johan \"{O}stman and Yury Polyanskiy and Wei Yang},
 	Date-Added = {2014-12-09 14:07:56 +0000},
 	Date-Modified = {2016-09-02 05:36:21 +0000},
-	Journal = {IEEE_J_COM},
+	Journal = IEEE_J_COM,
 	Keywords = {giuseppe},
 	Month = feb,
 	Number = {2},


### PR DESCRIPTION
Previously, manual.pdf didn't compile (with TexLive under Linux). FIxed this (small fix).